### PR TITLE
Fix Doxygen

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,4 +64,4 @@ import subprocess, os
 read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
 
 if read_the_docs_build:
-    subprocess.call("doxygen", shell=True)
+    subprocess.call("cd ..; doxygen", shell=True)


### PR DESCRIPTION
Doxygen doesn't build because it's called from the wrong directory.