### PR TITLE
Update installing.md

### DIFF
--- a/docs/source/guides/installing.md
+++ b/docs/source/guides/installing.md
@@ -38,5 +38,5 @@ pros c apply robodash
 You can now add the following to your project's `main.h` file to use robodash.
 
 ```cpp
-#include "robodash/api.hpp"
+#include "robodash/api.h"
 ```


### PR DESCRIPTION
**Minor Docs Fix**

In the latest version of RoboDash installed from depot, there is no `robodash/api.hpp` file as the docs instruct users to include, but rather `robodash/api.h`