### PR TITLE
Fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ system to improve compatibility with templates that provide LVGL-powered
 GUIs.
 
 Get started with robodash by reading
-[the docs](https://unwieldycat.github.io/robodash/).
+[the docs](https://robodash.readthedocs.io/en/latest/).
 
 ### Screenshots
 


### PR DESCRIPTION
Updated the link to the docs. Also, the images lead give 404s but idk what the correct URL is for those.