### PR TITLE
Fix images constructed with C array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changes to this project will be logged in this file. This project uses
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Format is loosely
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+# 2.1.2
+
+Robodash 2.1.2 provides a fix for the image widget.
+
+> [!WARNING] This update has a breaking change
+>
+> When constructing an `rd::Image` with a C array, you must pass a pointer to
+> your `lv_img_dsc_t` instead of a reference. This is to prevent a dangling
+> pointer.
+
+### Fixed
+
+- A bug where constructing an `rd::Image` with a C array would not display the
+  image.
+
 ## 2.1.1
 
 Robodash 2.1.1 is a recompilation of 2.1.0 that upgrades to PROS version 4.1.0

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ EXCLUDE_COLD_LIBRARIES:=
 # Set this to 1 to add additional rules to compile your project as a PROS library template
 IS_LIBRARY:=1
 LIBNAME:=robodash
-VERSION:=2.1.1
+VERSION:=2.1.2
 
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files

--- a/docs/source/guides/usage/widgets.md
+++ b/docs/source/guides/usage/widgets.md
@@ -71,13 +71,13 @@ convert the image to a C array and place it in your project's `src` directory,
 or convert it to a a binary file and load it onto a microSD card.
 
 To create an image, we can construct it with a path to an LVGL-converted
-`image.bin` file on a loaded SD card, or to an LVGL image variable. You also
-must pass a name to the image.
+`image.bin` file on a loaded SD card, or a pointer to an LVGL image variable.
+You also must pass a name to the image.
 
 ```cpp
 // microSD approach
 rd::Image image1("S:/usd/logo.bin", "Team Logo");
 
 // C array approach
-rd::Image image2(team_logo, "Team Logo")
+rd::Image image2(&team_logo, "Team Logo")
 ```

--- a/include/robodash/views/image.hpp
+++ b/include/robodash/views/image.hpp
@@ -51,7 +51,7 @@ class Image {
 	 * @param image_dsc Pointer to LVGL image descriptor object
 	 * @param name Name to display on screen
 	 */
-	Image(lv_img_dsc_t &image_dsc, std::string name = "Image");
+	Image(lv_img_dsc_t *image_dsc, std::string name = "Image");
 
 	/**
 	 * @brief Set this view to the active view

--- a/include/robodash/views/image.hpp
+++ b/include/robodash/views/image.hpp
@@ -48,10 +48,10 @@ class Image {
 	/**
 	 * @brief Create a new Image
 	 *
-	 * @param image_dsc LVGL image descriptor object
+	 * @param image_dsc Pointer to LVGL image descriptor object
 	 * @param name Name to display on screen
 	 */
-	Image(lv_img_dsc_t image_dsc, std::string name = "Image");
+	Image(lv_img_dsc_t &image_dsc, std::string name = "Image");
 
 	/**
 	 * @brief Set this view to the active view

--- a/src/robodash/views/image.cpp
+++ b/src/robodash/views/image.cpp
@@ -3,7 +3,7 @@
 
 // ============================= Core Functions ============================= //
 
-rd::Image::Image(lv_img_dsc_t &image_dsc, std::string name) {
+rd::Image::Image(lv_img_dsc_t *image_dsc, std::string name) {
 	this->view = rd_view_create(name.c_str());
 	lv_obj_t *image = lv_img_create(view->obj);
 	lv_img_set_src(image, image_dsc);

--- a/src/robodash/views/image.cpp
+++ b/src/robodash/views/image.cpp
@@ -3,12 +3,10 @@
 
 // ============================= Core Functions ============================= //
 
-rd::Image::Image(lv_img_dsc_t image_dsc, std::string name) {
-	if (!pros::usd::is_installed()) return;
-
+rd::Image::Image(lv_img_dsc_t &image_dsc, std::string name) {
 	this->view = rd_view_create(name.c_str());
 	lv_obj_t *image = lv_img_create(view->obj);
-	lv_img_set_src(image, &image_dsc);
+	lv_img_set_src(image, image_dsc);
 	lv_obj_align(image, LV_ALIGN_CENTER, 0, 0);
 	rd_view_set_anims(this->view, RD_ANIM_OFF);
 }


### PR DESCRIPTION
This PR fixes multiple issues in the `rd::Image` constructor that prevented images being created with a C array.